### PR TITLE
add shouldTriggerLoad callback function prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It is really easy to use. The actual rows of content should be passed as **child
  * `className` extra css class string for the container
  * `flipped` true for chat (newest at bottom), regular for newsfeed (newest at top)
  * `scrollLoadThreshold` pixel distance from top that triggers an infinite load
+ * `shouldTriggerLoad` callback function to check if chat view should trigger infinite load cycle when scroll passed `scrollLoadThreshold`. This callback is optional and by default  `onInfiniteLoad` is always triggered. 
  * `onInfiniteLoad` load request callback, should cause a state change which renders more children
 
 See the [jsfiddle example](https://jsfiddle.net/dustingetz/xvqzw747/) for a complete working example.

--- a/src/react-chatview.js
+++ b/src/react-chatview.js
@@ -17,6 +17,7 @@ var ChatView = React.createClass({
   propTypes: {
     flipped: React.PropTypes.bool,
     scrollLoadThreshold: React.PropTypes.number,
+    shouldTriggerLoad: React.PropTypes.func,
     onInfiniteLoad: React.PropTypes.func.isRequired,
     loadingSpinnerDelegate: React.PropTypes.element,
     className: React.PropTypes.string
@@ -26,6 +27,7 @@ var ChatView = React.createClass({
     return {
       flipped: false,
       scrollLoadThreshold: 10,
+      shouldTriggerLoad: function() { return true; },
       loadingSpinnerDelegate: <div/>,
       className: ''
     };
@@ -100,7 +102,7 @@ var ChatView = React.createClass({
         domNode.scrollTop,
         domNode.scrollHeight,
         domNode.clientHeight);
-    return passedThreshold && !this.state.isInfiniteLoading;
+    return passedThreshold && !this.state.isInfiniteLoading && this.props.shouldTriggerLoad();
   },
 
   componentDidMount () {


### PR DESCRIPTION
To allow developer decide if chat view should trigger `onInfiniteLoad` when scroll position passed `scrollLoadThreshold`.
Otherwise it always trying to load more children, `isInfiniteLoading` state changes and spinner is showing unnecessary.